### PR TITLE
Add Chinese-ELECTRA PaddlePaddle version, quick access these models through PaddleHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@
 
 
 ## 新闻
-2020/3/25 Chinese ELECTRA-small/base已发布，请查看[模型下载](#模型下载)
+2020/3/31 本目录发布的模型已接入[飞桨PaddleHub](https://github.com/PaddlePaddle/PaddleHub)，查看[快速加载](#快速加载)
 
+2020/3/25 Chinese ELECTRA-small/base已发布，请查看[模型下载](#模型下载)
 
 ## 内容导引
 | 章节 | 描述 |
@@ -67,6 +68,20 @@ chinese_electra_small_L-12_H-256_A-4.zip
     |- vocab.txt            	            # 词表
 ```
 
+### 快速加载
+依托[PaddleHub](https://github.com/PaddlePaddle/PaddleHub)，我们只需一行代码即可完成模型下载安装，十余行代码即可完成文本分类、序列标注、阅读理解等任务。
+
+```
+import paddlehub as hub
+module = hub.Module(name=MODULE_NAME)
+```
+
+其中`MODULE_NAME`对应列表如下：
+
+| 模型名 | MODULE_NAME |
+| - | - |
+| ELECTRA-base | [chinese-electra-base](https://paddlepaddle.org.cn/hubdetail?name=chinese-electra-base&en_category=SemanticModel) |
+| ELECTRA-small  | [chinese-electra-small](https://paddlepaddle.org.cn/hubdetail?name=chinese-electra-small&en_category=SemanticModel) |
 
 ### 训练细节
 我们采用了大规模中文维基以及通用文本训练了ELECTRA模型，总token数达到5.4B，与[RoBERTa-wwm-ext系列模型](https://github.com/ymcui/Chinese-BERT-wwm)一致。词表方面沿用了谷歌原版BERT的WordPiece词表，包含21128个token。其他细节和超参数如下（未提及的参数保持默认）：

--- a/README_EN.md
+++ b/README_EN.md
@@ -9,6 +9,8 @@ This project is based on the official code of ELECTRA: [https://github.com/googl
 
 
 ## News
+March 31, 2020  The models in this repository now can be easily accessed through [PaddleHub](https://github.com/PaddlePaddle/PaddleHub), check [Quick Load](#Quick-Load)
+
 March 25, 2020  We have released Chinese ELECTRA-small/base models, check [Download](#Download).
 
 
@@ -55,6 +57,21 @@ chinese_electra_small_L-12_H-256_A-4.zip
     |- electra_small.index                  # Index info
     |- vocab.txt                            # Vocabulary
 ```
+
+### Quick Load
+With [PaddleHub](https://github.com/PaddlePaddle/PaddleHub), we can download and install the model with one line of code.
+
+```
+import paddlehub as hub
+module = hub.Module(name=MODULE_NAME)
+```
+
+The actual model and its `MODULE_NAME` are listed below.
+
+| Original Model| MODULE_NAME |
+| - | - |
+| ELECTRA-base | [chinese-electra-base](https://paddlepaddle.org.cn/hubdetail?name=chinese-electra-base&en_category=SemanticModel) |
+| ELECTRA-small  | [chinese-electra-small](https://paddlepaddle.org.cn/hubdetail?name=chinese-electra-small&en_category=SemanticModel) |
 
 ### Training Details
 We use the same data for training [RoBERTa-wwm-ext model series](https://github.com/ymcui/Chinese-BERT-wwm), which includes 5.4B tokens.


### PR DESCRIPTION
Hi, ymcui. PaddleHub has supported the models in this repo. We add Chinese-ELECTRA PaddlePaddle version in this PR, people can download and install models through PaddleHub easily.